### PR TITLE
use tokyo region

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -7,6 +7,7 @@ frameworkVersion: '3'
 provider:
   name: aws
   runtime: nodejs14.x
+  region: ap-northeast-1
 
 functions:
   # rateHandler:


### PR DESCRIPTION
- serverless-layer を使うためにS3のバケットを作った
- region を東京に指定して作った
- serverless.yml にも `region:` を指定した
- lambda の region も一緒に変わる → ログが出てこない。。となって時間を溶かしたので先に全体で東京を使うようにしておく