### PR TITLE
pass params from cron

### DIFF
--- a/config/pageList.yml
+++ b/config/pageList.yml
@@ -1,0 +1,5 @@
+pages:
+  - name: "Googleトップ"
+    url: "https://google.com"
+  - name: "Yahooトップ"
+    url: "https://www.yahoo.co.jp/"

--- a/handler.ts
+++ b/handler.ts
@@ -24,7 +24,6 @@ export const lighthouse = async (event: Event) => {
   console.log("event::", event);
   console.log("name::", event.targetPage.name);
   console.log("url::", event.targetPage.url);
-  console.log("hoge::", event.hoge);
   console.log("process.env.envName::", process.env.envName);
   // console.log("process.env.DATADOG_API_KEY::", process.env.DATADOG_API_KEY);
   console.log("process.env.datadogApiKey::", process.env.datadogApiKey);

--- a/handler.ts
+++ b/handler.ts
@@ -8,8 +8,23 @@ export const run = async (event: any, context: any) => {
   console.log(`Your cron function "${context.functionName}" ran at ${time}, neripark!`);
 };
 
-export const lighthouse = async (event: any) => {
+// _____________________________
+interface Page {
+  name: string;
+  url: string;
+}
+type NativeEvent = any;
+interface ExtendedEvent {
+  targetPage: Page;
+};
+interface Event extends ExtendedEvent, NativeEvent {};
+// _____________________________
+
+export const lighthouse = async (event: Event) => {
   console.log("event::", event);
+  console.log("name::", event.targetPage.name);
+  console.log("url::", event.targetPage.url);
+  console.log("hoge::", event.hoge);
   console.log("process.env.envName::", process.env.envName);
   // console.log("process.env.DATADOG_API_KEY::", process.env.DATADOG_API_KEY);
   console.log("process.env.datadogApiKey::", process.env.datadogApiKey);

--- a/handler.ts
+++ b/handler.ts
@@ -15,7 +15,7 @@ export const lighthouse = async (event: any) => {
   console.log("process.env.datadogApiKey::", process.env.datadogApiKey);
 
   // 今は切り離しているので単独で実行
-  sendMetricsToDatadog();
+  // sendMetricsToDatadog();
   // ref: https://chuckwebtips.hatenablog.com/entry/2021/05/14/220648
   return audit();
 };

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,7 +27,14 @@ functions:
     handler: handler.lighthouse
     events:
       # - schedule: cron(10,30,50 * ? * MON-FRI *)
-      - schedule: cron(0 12 ? * FRI *)
+
+      - schedule:
+          rate: cron(10,30,50 * ? * MON-FRI *)
+          input:
+            pageName: "Googleトップ"
+            url: "https://google.com"
+
+      # - schedule: cron(0 12 ? * FRI *)
     timeout: 60
     environment:
       envName: ${self:custom.otherfile.environment.${self:provider.stage}.envName}

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,8 +31,7 @@ functions:
       - schedule:
           rate: cron(10,30,50 * ? * MON-FRI *)
           input:
-            pageName: "Googleトップ"
-            url: "https://google.com"
+            item: ${self:custom.otherfile.pageList.pages.0}
 
       # - schedule: cron(0 12 ? * FRI *)
     timeout: 60
@@ -51,6 +50,7 @@ custom:
       local: ${file(./config/local.yml)}
       dev: ${file(./config/dev.yml)}
       prd: ${file(./config/prd.yml)}
+    pageList: ${file(./config/pageList.yml)}
 
 # Note:
 # - rateHandler.handler と cronHandler.handlerを両方定義したら、rateHandler のみがAWS側に認識された。

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,10 +28,15 @@ functions:
     events:
       # - schedule: cron(10,30,50 * ? * MON-FRI *)
 
+      # lighthouse は Map で並列実行できないので起動プロセスで分ける
       - schedule:
-          rate: cron(10,30,50 * ? * MON-FRI *)
+          rate: ${self:custom.config.rate}
           input:
-            item: ${self:custom.otherfile.pageList.pages.0}
+            targetPage: ${self:custom.otherfile.pageList.pages.0}
+      - schedule:
+          rate: ${self:custom.config.rate}
+          input:
+            targetPage: ${self:custom.otherfile.pageList.pages.1}
 
       # - schedule: cron(0 12 ? * FRI *)
     timeout: 60
@@ -45,6 +50,8 @@ custom:
   serverless-layers:
     layersDeploymentBucket: sls-lambda-node-cron-layer
     # dependenciesPath: ./package.json
+  config:
+    rate: cron(10,30,50 * ? * MON-FRI *) 
   otherfile:
     environment:
       local: ${file(./config/local.yml)}

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,10 +31,12 @@ functions:
       # lighthouse は Map で並列実行できないので起動プロセスで分ける
       - schedule:
           rate: ${self:custom.config.rate}
+          enabled: false # 実行するときは削除
           input:
             targetPage: ${self:custom.otherfile.pageList.pages.0}
       - schedule:
           rate: ${self:custom.config.rate}
+          enabled: false # 実行するときは削除
           input:
             targetPage: ${self:custom.otherfile.pageList.pages.1}
 


### PR DESCRIPTION
- 対象ページを起動時にcronから渡すようにする
  - lighthouse は同一プロセス内で複数並列実行できない
- `schedule.rate` を custom フィールドに切り出し
- Event に型を生やしてコーディング時にわかるようにする